### PR TITLE
hide api key + simplify redundency in pom.xml file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+APITOKENKEY = **insert token here no quotations no semicolon

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+###
+.env

--- a/pom.xml
+++ b/pom.xml
@@ -14,18 +14,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>5.10.0</junit.version>
     </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>14</source>
-                    <target>14</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <!-- JUnit 5 -->
@@ -42,10 +30,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.8.1</version>
-            <scope>test</scope>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>java-dotenv</artifactId>
+            <version>5.2.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/data_access/TMDbMovieDataAccessObject.java
+++ b/src/main/java/data_access/TMDbMovieDataAccessObject.java
@@ -13,6 +13,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+// for the hiding of api
+import io.github.cdimascio.dotenv.Dotenv;
 
 
 public class TMDbMovieDataAccessObject implements MovieGateway {
@@ -23,7 +25,9 @@ public class TMDbMovieDataAccessObject implements MovieGateway {
 
     // makeRequest actually makes the api call
     private String makeRequest(String url) throws Exception {
-        String apiToken = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI1ODA5YTFjMmQzNDhjNjI3MDk1ZDllNzY3Y2Y0NWQ2MSIsIm5iZiI6MTc2MjgwODI3Mi4xNDQsInN1YiI6IjY5MTI1MWQwODA0Nzc2ZGJlMmQyNWU2MiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.qx1FvwXuldaEQZeXupCmT9FyBjoU3nrGcSSM_hVHFP8";
+        final String apiToken;
+        Dotenv dotenv = Dotenv.load();
+        apiToken = dotenv.get("APITOKENKEY");
 
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))


### PR DESCRIPTION
closes #46 .   I got rid of some redundancy in the pom.xml file, and also added a dependency that allows for accessing .env variables. Please note that you have to create your own .env file locally (copy the same format as .env.example) and paste in the api key (can be accessed on the google doc.)