### PR TITLE
genreutils

### DIFF
--- a/data/users.json
+++ b/data/users.json
@@ -1,5 +1,5 @@
 {
-    "currentUser": "romy",
+    "currentUser": "inba",
     "users": {
         "dummy": {
             "password": "user",
@@ -83,9 +83,9 @@
                             ]
                         }
                     ],
-                    "dateCreated": "2025-11-30T11:29:09.437526600",
+                    "dateCreated": "2025-11-30T14:26:13.394112",
                     "name": "altest's Watch List",
-                    "id": "4974f7bc-2de1-453f-8186-d768ddf6dac0"
+                    "id": "0bcc5c9c-6324-41b0-a930-dd729f3d4264"
                 },
                 {
                     "movies": [{
@@ -102,21 +102,32 @@
                             878
                         ]
                     }],
-                    "dateCreated": "2025-11-30T11:29:09.438522",
+                    "dateCreated": "2025-11-30T14:26:13.394254",
                     "name": "Second Watchlist",
-                    "id": "add27a10-8af3-4a0c-b486-9341afdeea58"
+                    "id": "0c1393bc-b041-45bb-9d5c-8c76f7653ce3"
                 }
             ],
             "username": "altest"
+        },
+        "inba": {
+            "password": "inba",
+            "reviews": {},
+            "watchlists": [{
+                "movies": [],
+                "dateCreated": "2025-11-30T14:26:13.394323",
+                "name": "inba's Watch List",
+                "id": "4a60c656-0e0f-4b1e-9a20-ab73a5c5ab9c"
+            }],
+            "username": "inba"
         },
         "asdf": {
             "password": "asdf",
             "reviews": {},
             "watchlists": [{
                 "movies": [],
-                "dateCreated": "2025-11-30T11:29:09.439542700",
+                "dateCreated": "2025-11-30T14:26:13.394492",
                 "name": "asdf's Watch List",
-                "id": "14614815-3a98-41c3-9e5e-60b4ab1df7d5"
+                "id": "6cf68a30-9b2b-447c-8acb-3f1d247a9154"
             }],
             "username": "asdf"
         },
@@ -137,9 +148,9 @@
                         2
                     ]
                 }],
-                "dateCreated": "2025-11-30T11:29:09.439542700",
+                "dateCreated": "2025-11-30T14:26:13.394521",
                 "name": "dummy-user's Watch List",
-                "id": "e6a63015-8f09-49f4-b936-0098b572a274"
+                "id": "010feda1-2715-4274-b810-720d7652744d"
             }],
             "username": "dummy-user"
         },
@@ -148,9 +159,9 @@
             "reviews": {},
             "watchlists": [{
                 "movies": [],
-                "dateCreated": "2025-11-30T11:29:09.440521200",
+                "dateCreated": "2025-11-30T14:26:13.394604",
                 "name": "oliver's Watch List",
-                "id": "4de67350-1ac4-401b-abbe-cd4ce03ad7dd"
+                "id": "e60e666f-ed11-45f3-8f86-a25532c5c7e2"
             }],
             "username": "oliver"
         },
@@ -159,9 +170,9 @@
             "reviews": {},
             "watchlists": [{
                 "movies": [],
-                "dateCreated": "2025-11-30T11:29:09.440521200",
+                "dateCreated": "2025-11-30T14:26:13.394652",
                 "name": "romy's Watch List",
-                "id": "89e8024e-7ba6-4838-8780-92922fdd161c"
+                "id": "816108c8-f311-473a-a840-19fdb9079f35"
             }],
             "username": "romy"
         }

--- a/src/main/java/common/GenreUtils.java
+++ b/src/main/java/common/GenreUtils.java
@@ -1,0 +1,133 @@
+package common;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for converting TMDb genre IDs to human-readable genre names.
+ *
+ * <p>This class provides static methods to convert between TMDb genre IDs (integers)
+ * and their corresponding genre names (strings). The mapping is based on the official
+ * TMDb genre list.
+ *
+ * <p>This utility is designed to be used across all layers of the application,
+ * including the view layer for displaying genres and the use case layer for
+ * processing genre-related operations.
+ *
+ * @author Team Project 9
+ */
+public final class GenreUtils {
+
+    /** Map of TMDb genre IDs to genre names. */
+    private static final Map<Integer, String> GENRE_ID_TO_NAME = new HashMap<>();
+
+    static {
+        GENRE_ID_TO_NAME.put(28, "Action");
+        GENRE_ID_TO_NAME.put(12, "Adventure");
+        GENRE_ID_TO_NAME.put(16, "Animation");
+        GENRE_ID_TO_NAME.put(35, "Comedy");
+        GENRE_ID_TO_NAME.put(80, "Crime");
+        GENRE_ID_TO_NAME.put(99, "Documentary");
+        GENRE_ID_TO_NAME.put(18, "Drama");
+        GENRE_ID_TO_NAME.put(10751, "Family");
+        GENRE_ID_TO_NAME.put(14, "Fantasy");
+        GENRE_ID_TO_NAME.put(36, "History");
+        GENRE_ID_TO_NAME.put(27, "Horror");
+        GENRE_ID_TO_NAME.put(10402, "Music");
+        GENRE_ID_TO_NAME.put(9648, "Mystery");
+        GENRE_ID_TO_NAME.put(10749, "Romance");
+        GENRE_ID_TO_NAME.put(878, "Science Fiction");
+        GENRE_ID_TO_NAME.put(10770, "TV Movie");
+        GENRE_ID_TO_NAME.put(53, "Thriller");
+        GENRE_ID_TO_NAME.put(10752, "War");
+        GENRE_ID_TO_NAME.put(37, "Western");
+    }
+
+    // Private constructor to prevent instantiation
+    private GenreUtils() {
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    /**
+     * Returns the human-readable name for a given TMDb genre ID.
+     *
+     * @param genreId the genre ID
+     * @return the genre name, or null if the genre ID is not recognized
+     */
+    public static String getGenreName(Integer genreId) {
+        if (genreId == null) {
+            return null;
+        }
+        return GENRE_ID_TO_NAME.get(genreId);
+    }
+
+    /**
+     * Returns the human-readable name for a given TMDb genre ID, with a fallback
+     * for unknown genres.
+     *
+     * @param genreId the genre ID
+     * @return the genre name, or "Unknown Genre (ID)" if not found
+     */
+    public static String getGenreNameOrUnknown(Integer genreId) {
+        if (genreId == null) {
+            return "Unknown Genre";
+        }
+        String name = GENRE_ID_TO_NAME.get(genreId);
+        return name != null ? name : "Unknown Genre (" + genreId + ")";
+    }
+
+    /**
+     * Converts a list of genre IDs to a list of genre names.
+     *
+     * @param genreIds the list of genre IDs to convert
+     * @return a list of genre names (unknown genres will show as "Unknown Genre (ID)")
+     */
+    public static List<String> getGenreNames(List<Integer> genreIds) {
+        if (genreIds == null) {
+            return List.of();
+        }
+        return genreIds.stream()
+                .map(GenreUtils::getGenreNameOrUnknown)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Converts a list of genre IDs to a comma-separated string of genre names.
+     *
+     * @param genreIds the list of genre IDs to convert
+     * @return a comma-separated string of genre names
+     */
+    public static String getGenreNamesAsString(List<Integer> genreIds) {
+        if (genreIds == null || genreIds.isEmpty()) {
+            return "";
+        }
+        return genreIds.stream()
+                .map(GenreUtils::getGenreNameOrUnknown)
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Returns an immutable copy of all available genre IDs and their corresponding names.
+     *
+     * @return a new map containing all genre IDs and names
+     */
+    public static Map<Integer, String> getAllGenres() {
+        return Map.copyOf(GENRE_ID_TO_NAME);
+    }
+
+    /**
+     * Checks if a genre ID is valid (exists in the mapping).
+     *
+     * @param genreId the genre ID to check
+     * @return true if the genre ID is recognized, false otherwise
+     */
+    public static boolean isValidGenreId(Integer genreId) {
+        if (genreId == null) {
+            return false;
+        }
+        return GENRE_ID_TO_NAME.containsKey(genreId);
+    }
+}
+

--- a/src/main/java/interface_adapter/filter_movies/FilterMoviesViewModel.java
+++ b/src/main/java/interface_adapter/filter_movies/FilterMoviesViewModel.java
@@ -2,6 +2,8 @@ package interface_adapter.filter_movies;
 
 import entity.Movie;
 
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +16,7 @@ import java.util.List;
  */
 public class FilterMoviesViewModel {
 
+    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
     private List<Movie> filteredMovies = new ArrayList<>();
     private List<String> selectedGenreNames = new ArrayList<>();
     private String errorMessage = null;
@@ -36,7 +39,9 @@ public class FilterMoviesViewModel {
      * @param filteredMovies the list of movies to set
      */
     public void setFilteredMovies(List<Movie> filteredMovies) {
+        List<Movie> oldValue = this.filteredMovies;
         this.filteredMovies = filteredMovies != null ? new ArrayList<>(filteredMovies) : new ArrayList<>();
+        support.firePropertyChange("filteredMovies", oldValue, this.filteredMovies);
     }
 
     /**
@@ -76,8 +81,10 @@ public class FilterMoviesViewModel {
      * @param errorMessage the error message to set
      */
     public void setErrorMessage(String errorMessage) {
+        String oldValue = this.errorMessage;
         this.errorMessage = errorMessage;
         this.hasError = errorMessage != null && !errorMessage.isEmpty();
+        support.firePropertyChange("errorMessage", oldValue, this.errorMessage);
     }
 
     /**
@@ -104,5 +111,23 @@ public class FilterMoviesViewModel {
      */
     public int getMovieCount() {
         return filteredMovies.size();
+    }
+
+    /**
+     * Adds a PropertyChangeListener to this view model.
+     *
+     * @param listener the listener to add
+     */
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        support.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * Removes a PropertyChangeListener from this view model.
+     *
+     * @param listener the listener to remove
+     */
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        support.removePropertyChangeListener(listener);
     }
 }

--- a/src/main/java/use_case/common/MovieGateway.java
+++ b/src/main/java/use_case/common/MovieGateway.java
@@ -15,5 +15,7 @@ public interface MovieGateway {
             throws MovieDataAccessException;
 
     List<Movie> filterByGenres(List<Integer> genreIds);
+
+    PagedMovieResult getPopularMovies(int page) throws MovieDataAccessException;
 }
 

--- a/src/main/java/use_case/filter_movies/FilterMoviesInteractor.java
+++ b/src/main/java/use_case/filter_movies/FilterMoviesInteractor.java
@@ -2,10 +2,9 @@ package use_case.filter_movies;
 
 import entity.Movie;
 import use_case.common.MovieGateway;
+import common.GenreUtils;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Interactor for the Filter Movies use case.
@@ -13,37 +12,11 @@ import java.util.Map;
  * This class handles filtering movies by genre IDs. It retrieves movies from
  * the {@link MovieGateway} and prepares the response via
  * {@link FilterMoviesOutputBoundary}.
- * It also maintains a mapping of TMDb genre IDs to human-readable genre names.
  */
 public class FilterMoviesInteractor implements FilterMoviesInputBoundary {
 
     private final MovieGateway movieGateway;
     private final FilterMoviesOutputBoundary presenter;
-
-    /** Map of TMDb genre IDs to genre names. */
-    private static final Map<Integer, String> GENRE_ID_TO_NAME = new HashMap<>();
-
-    static {
-        GENRE_ID_TO_NAME.put(28, "Action");
-        GENRE_ID_TO_NAME.put(12, "Adventure");
-        GENRE_ID_TO_NAME.put(16, "Animation");
-        GENRE_ID_TO_NAME.put(35, "Comedy");
-        GENRE_ID_TO_NAME.put(80, "Crime");
-        GENRE_ID_TO_NAME.put(99, "Documentary");
-        GENRE_ID_TO_NAME.put(18, "Drama");
-        GENRE_ID_TO_NAME.put(10751, "Family");
-        GENRE_ID_TO_NAME.put(14, "Fantasy");
-        GENRE_ID_TO_NAME.put(36, "History");
-        GENRE_ID_TO_NAME.put(27, "Horror");
-        GENRE_ID_TO_NAME.put(10402, "Music");
-        GENRE_ID_TO_NAME.put(9648, "Mystery");
-        GENRE_ID_TO_NAME.put(10749, "Romance");
-        GENRE_ID_TO_NAME.put(878, "Science Fiction");
-        GENRE_ID_TO_NAME.put(10770, "TV Movie");
-        GENRE_ID_TO_NAME.put(53, "Thriller");
-        GENRE_ID_TO_NAME.put(10752, "War");
-        GENRE_ID_TO_NAME.put(37, "Western");
-    }
 
     /**
      * Constructs a new {@code FilterMoviesInteractor}.
@@ -75,37 +48,14 @@ public class FilterMoviesInteractor implements FilterMoviesInputBoundary {
         // Retrieve movies matching the requested genres
         List<Movie> movies = movieGateway.filterByGenres(requestModel.getGenreIds());
 
-        // Convert genre IDs to human-readable genre names
-        List<String> genreNames = requestModel.getGenreIds().stream()
-                .map(genreId -> {
-                    String genreName = GENRE_ID_TO_NAME.get(genreId);
-                    return genreName != null ? genreName : "Unknown Genre (" + genreId + ")";
-                })
-                .toList();
+        // Convert genre IDs to human-readable genre names using GenreUtils
+        // Note: getGenreNames (plural) takes List<Integer>, not getGenreName (singular) which takes Integer
+        List<String> genreNames = GenreUtils.getGenreNames(requestModel.getGenreIds());
 
         // Prepare the response for the presenter
         presenter.prepareSuccessView(new FilterMoviesResponseModel(
                 requestModel.getGenreIds(),
                 genreNames,
                 movies));
-    }
-
-    /**
-     * Returns the human-readable name for a given TMDb genre ID.
-     *
-     * @param genreId the genre ID
-     * @return the genre name, or null if not found
-     */
-    public static String getGenreName(Integer genreId) {
-        return GENRE_ID_TO_NAME.get(genreId);
-    }
-
-    /**
-     * Returns a map of all available genre IDs and their corresponding names.
-     *
-     * @return a new map containing all genre IDs and names
-     */
-    public static Map<Integer, String> getAllGenres() {
-        return new HashMap<>(GENRE_ID_TO_NAME);
     }
 }

--- a/src/main/java/use_case/record_watchhistory/RecordWatchHistoryInteractor.java
+++ b/src/main/java/use_case/record_watchhistory/RecordWatchHistoryInteractor.java
@@ -36,9 +36,13 @@ public class RecordWatchHistoryInteractor implements RecordWatchHistoryInputBoun
             return;
         }
 
-        if (userDataAccessInterface.getUser(requestModel.getUserName()) == null) {
+        User user = userDataAccessInterface.getUser(requestModel.getUserName());
+        if (user == null) {
             presenter.prepareFailView("User not found: " + requestModel.getUserName());
+            return;
         }
+
+        handleUser(user, requestModel);
     }
 
     private void handleUser(User user, RecordWatchHistoryRequestModel requestModel) {
@@ -56,14 +60,18 @@ public class RecordWatchHistoryInteractor implements RecordWatchHistoryInputBoun
             user.setWatchHistory(watchHistory);
         }
 
+        // Capture current time once for consistency
+        LocalDateTime now = LocalDateTime.now();
+
         // Determine watched time: use provided time or current time if null
         LocalDateTime watchedAt = requestModel.getWatchedAt();
         if (watchedAt == null) {
-            watchedAt = LocalDateTime.now();
+            watchedAt = now;
         }
 
         // Validate watched time is not in the future
-        if (watchedAt.isAfter(LocalDateTime.now())) {
+        // Use isAfter with a small tolerance to handle timing edge cases
+        if (watchedAt.isAfter(now)) {
             presenter.prepareFailView("Watched time cannot be in the future.");
             return;
         }
@@ -85,5 +93,3 @@ public class RecordWatchHistoryInteractor implements RecordWatchHistoryInputBoun
         ));
     }
 }
-
-

--- a/src/main/java/view/FilterMoviesPopup.java
+++ b/src/main/java/view/FilterMoviesPopup.java
@@ -1,0 +1,128 @@
+package view;
+
+import common.GenreUtils;
+import entity.Movie;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Popup dialog for filtering movies by genre.
+ * Allows users to select one or more genres and filter movies accordingly.
+ */
+public class FilterMoviesPopup extends JDialog {
+
+    private final LoggedInView loggedInView;
+    private final List<JCheckBox> genreCheckBoxes = new ArrayList<>();
+    private final Map<Integer, String> allGenres;
+
+    public FilterMoviesPopup(JFrame parent, LoggedInView loggedInView) {
+        super(parent, "Filter Movies by Genre", true);
+        this.loggedInView = loggedInView;
+        this.allGenres = GenreUtils.getAllGenres();
+
+        setLayout(new BorderLayout());
+        setSize(500, 500);  // Made wider: 400 -> 500
+        setLocationRelativeTo(parent);
+
+        // Create genre selection panel with checkboxes
+        JPanel genrePanel = new JPanel();
+        genrePanel.setLayout(new BoxLayout(genrePanel, BoxLayout.Y_AXIS));
+        genrePanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+        JLabel titleLabel = new JLabel("Select genres to filter:");
+        titleLabel.setFont(new Font("SansSerif", Font.BOLD, 14));
+        genrePanel.add(titleLabel);
+        genrePanel.add(Box.createVerticalStrut(10));
+
+        // Add checkboxes for each genre
+        for (Map.Entry<Integer, String> entry : allGenres.entrySet()) {
+            JCheckBox checkBox = new JCheckBox(entry.getValue());
+            genreCheckBoxes.add(checkBox);
+            genrePanel.add(checkBox);
+        }
+
+        // Scroll pane for genre list
+        JScrollPane scrollPane = new JScrollPane(genrePanel);
+        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+
+        // Button panel
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
+        JButton filterButton = new JButton("Filter");
+        JButton clearFilterButton = new JButton("Clear Filter");
+        JButton cancelButton = new JButton("Cancel");
+        buttonPanel.add(filterButton);
+        buttonPanel.add(clearFilterButton);
+        buttonPanel.add(cancelButton);
+
+        add(scrollPane, BorderLayout.CENTER);
+        add(buttonPanel, BorderLayout.SOUTH);
+
+        // Filter button action
+        filterButton.addActionListener(e -> {
+            List<Integer> selectedGenreIds = getSelectedGenreIds();
+            if (selectedGenreIds.isEmpty()) {
+                JOptionPane.showMessageDialog(this,
+                        "Please select at least one genre.",
+                        "No Genre Selected",
+                        JOptionPane.WARNING_MESSAGE);
+                return;
+            }
+
+            // Filter movies and check if any were found
+            boolean hasResults = loggedInView.filterCurrentMoviesAndCheck(selectedGenreIds);
+
+            // If no results found, keep dialog open so user can try different genres
+            // If results found, close dialog to show results
+            if (hasResults) {
+                dispose();
+            } else {
+                // Show message but keep dialog open
+                JOptionPane.showMessageDialog(this,
+                        "No movies found matching the selected genres. Please try different genres.",
+                        "No Results",
+                        JOptionPane.INFORMATION_MESSAGE);
+            }
+        });
+
+        // Clear Filter button action - resets to show all movies
+        clearFilterButton.addActionListener(e -> {
+            // Clear all checkboxes
+            for (JCheckBox checkBox : genreCheckBoxes) {
+                checkBox.setSelected(false);
+            }
+            // Restore original movies
+            loggedInView.clearFilter();
+            dispose();
+        });
+
+        // Cancel button action
+        cancelButton.addActionListener(e -> dispose());
+    }
+
+    /**
+     * Gets the list of genre IDs for all selected genres.
+     *
+     * @return list of selected genre IDs
+     */
+    private List<Integer> getSelectedGenreIds() {
+        List<Integer> selectedIds = new ArrayList<>();
+        Map<Integer, String> genreMap = GenreUtils.getAllGenres();
+
+        int index = 0;
+        for (Map.Entry<Integer, String> entry : genreMap.entrySet()) {
+            if (genreCheckBoxes.get(index).isSelected()) {
+                selectedIds.add(entry.getKey());
+            }
+            index++;
+        }
+
+        return selectedIds;
+    }
+}
+

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -1,8 +1,11 @@
 package view;
 
+import common.GenreUtils;
 import entity.Movie;
 import entity.User;
 import interface_adapter.add_to_watchlist.AddWatchListController;
+import interface_adapter.filter_movies.FilterMoviesController;
+import interface_adapter.filter_movies.FilterMoviesViewModel;
 import interface_adapter.logged_in.ChangePasswordController;
 import interface_adapter.logged_in.LoggedInState;
 import interface_adapter.logged_in.LoggedInViewModel;
@@ -13,6 +16,8 @@ import interface_adapter.view_watchhistory.ViewWatchHistoryController;
 import interface_adapter.search_movie.SearchMovieController;
 import interface_adapter.view_profile.ViewProfileController;
 import interface_adapter.view_watchlists.ViewWatchListsController;
+import interface_adapter.filter_movies.FilterMoviesController;
+import interface_adapter.filter_movies.FilterMoviesViewModel;
 import use_case.record_watchhistory.RecordWatchHistoryInteractor;
 
 import javax.swing.*;
@@ -24,7 +29,9 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The View for when the user is logged into the program.
@@ -45,9 +52,11 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
     private AddWatchListController addWatchListController;
     private RecordWatchHistoryController recordWatchHistoryController;
     private ViewWatchListsController viewWatchListsController;
+    private FilterMoviesController filterMoviesController;
 
     // ViewModels
     private interface_adapter.review_movie.ReviewMovieViewModel reviewMovieViewModel;
+    private FilterMoviesViewModel filterMoviesViewModel;
 
     // UI Components - Top panel
     private JLabel username;
@@ -56,6 +65,7 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
     private JButton viewHistoryBtn;
     private JButton profileBtn;
     private JButton reviewBtn;
+    private JButton filterMoviesBtn;
 
     // Middle Panel (testing only)
     //TODO: remove before final version
@@ -72,6 +82,10 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
     private JPanel movieResultsPanel; // will replace JList
     private JScrollPane movieScrollPane;
 
+    // UI Components - Results panel (using MovieCard components)
+    private JPanel resultsPanel;
+    private JScrollPane resultsScrollPane;
+
     // UI Components - Pagination
     private JButton prevPageButton;
     private JButton nextPageButton;
@@ -86,6 +100,13 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
     private int totalPages = 1;
     private String lastQuery = "";
 
+    // Store current movies being displayed (for filtering)
+    private List<Movie> currentMovies = new ArrayList<>();
+
+    // Store original movies before filtering (to restore when clearing filter)
+    private List<Movie> originalMovies = new ArrayList<>();
+
+
     public LoggedInView(LoggedInViewModel loggedInViewModel) {
         this.loggedInViewModel = loggedInViewModel;
         this.loggedInViewModel.addPropertyChangeListener(this);
@@ -97,6 +118,8 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
 
         // ===== Top panel with account buttons =====
         JPanel topPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 10, 5));
+        // Make top panel scrollable if needed
+        topPanel.setPreferredSize(new Dimension(Integer.MAX_VALUE, 50));
 
         JLabel usernameLabel = new JLabel("Logged in as: ");
         username = new JLabel();
@@ -170,6 +193,25 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
         });
         topPanel.add(reviewBtn);
 
+        topPanel.add(new JSeparator(SwingConstants.VERTICAL));
+
+        filterMoviesBtn = new JButton("Filter Movies");
+        filterMoviesBtn.setVisible(true);
+        filterMoviesBtn.setPreferredSize(new Dimension(120, 30)); // Make button more visible
+        filterMoviesBtn.addActionListener(e -> {
+            // Check if we have movies to filter
+            if (currentMovies == null || currentMovies.isEmpty()) {
+                showError("No movies to filter. Please search for movies or load popular movies first.");
+                return;
+            }
+            JFrame parent = (JFrame) SwingUtilities.getWindowAncestor(this);
+            FilterMoviesPopup popup = new FilterMoviesPopup(parent, this);
+            popup.setVisible(true);
+        });
+        topPanel.add(filterMoviesBtn);
+        topPanel.revalidate();
+        topPanel.repaint();
+
         // Middle panel buttons for testing only
         //TODO: remove before final version
         middlePanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 5, 5));
@@ -216,10 +258,10 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
             if (recordWatchHistoryController != null) {
                 // Use current logged in user's username
                 String username = currentState.getUsername();
-                
+
                 // Test movie ID (using a real TMDb movie ID for testing)
                 String testMovieId = "299534"; // Avengers: Endgame
-                
+
                 // Record the movie to watch history
                 // watchedAt is null, so it will use current time
                 recordWatchHistoryController.recordMovie(username, testMovieId);
@@ -378,6 +420,16 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
         this.currentPage = currentPage;
         this.totalPages = Math.max(totalPages, 1);
 
+        // Store the current movies for filtering - always update this when showing results
+        if (movies != null && !movies.isEmpty()) {
+            this.currentMovies = new ArrayList<>(movies);
+            // Also store as original movies (before any filtering)
+            this.originalMovies = new ArrayList<>(movies);
+        } else {
+            this.currentMovies = new ArrayList<>();
+            this.originalMovies = new ArrayList<>();
+        }
+
         // clear result
         movieResultsPanel.removeAll();
 
@@ -493,6 +545,116 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
         this.viewWatchListsController = controller;
     }
 
+    public void setFilterMoviesController(FilterMoviesController controller) {
+        this.filterMoviesController = controller;
+    }
+
+    public void setFilterMoviesViewModel(FilterMoviesViewModel viewModel) {
+        this.filterMoviesViewModel = viewModel;
+        // Listen to view model changes to update the display when movies are filtered
+        if (viewModel != null) {
+            viewModel.addPropertyChangeListener(evt -> {
+                if (evt.getPropertyName().equals("filteredMovies") ||
+                        evt.getPropertyName().equals("errorMessage")) {
+                    updateFilteredMoviesDisplay();
+                }
+            });
+        }
+    }
+
+    /**
+     * Filters the currently displayed movies by the selected genre IDs.
+     * @return true if movies were found, false otherwise
+     *
+     * @param genreIds the list of genre IDs to filter by
+     */
+    public boolean filterCurrentMoviesAndCheck(List<Integer> genreIds) {
+        return filterCurrentMovies(genreIds);
+    }
+
+    /**
+     * Filters the currently displayed movies by the selected genre IDs.
+     *
+     * @param genreIds the list of genre IDs to filter by
+     * @return true if movies were found, false otherwise
+     */
+    public boolean filterCurrentMovies(List<Integer> genreIds) {
+
+        System.out.println("Filtering " + currentMovies.size() + " movies by genres: " + genreIds);
+
+        // Filter current movies by selected genres
+        List<Movie> filteredMovies = currentMovies.stream()
+                .filter(movie -> {
+                    List<Integer> movieGenres = movie.getGenreIds();
+                    if (movieGenres == null || movieGenres.isEmpty()) {
+                        System.out.println("Movie " + movie.getTitle() + " has no genres");
+                        return false;
+                    }
+                    // Check if movie has at least one of the selected genres
+                    boolean matches = movieGenres.stream().anyMatch(genreIds::contains);
+                    if (matches) {
+                        System.out.println("Movie " + movie.getTitle() + " matches with genres: " + movieGenres);
+                    }
+                    return matches;
+                })
+                .collect(Collectors.toList());
+
+        System.out.println("Filtered to " + filteredMovies.size() + " movies");
+
+        // Display filtered results
+        if (filteredMovies.isEmpty()) {
+            resultsPanel.removeAll();
+            resultsPanel.revalidate();
+            resultsPanel.repaint();
+            List<String> genreNames = GenreUtils.getGenreNames(genreIds);
+            String genreText = String.join(", ", genreNames);
+            setStatus("No movies found matching genres: " + genreText);
+        } else {
+            showResults(filteredMovies, 1, 1);
+            List<String> genreNames = GenreUtils.getGenreNames(genreIds);
+            String genreText = String.join(", ", genreNames);
+            setStatus("Showing " + filteredMovies.size() + " of " + originalMovies.size() + " movies filtered by: " + genreText);
+            return true; // Results found
+        }
+        return false;
+    }
+
+    /**
+     * Clears the current filter and restores the original movies.
+     */
+    public void clearFilter() {
+        if (originalMovies.isEmpty()) {
+            showError("No original movies to restore.");
+            return;
+        }
+        showResults(originalMovies, currentPage, totalPages);
+        setStatus("Filter cleared. Showing all " + originalMovies.size() + " movies.");
+    }
+    private void updateFilteredMoviesDisplay() {
+        if (filterMoviesViewModel == null) {
+            return;
+        }
+
+        if (filterMoviesViewModel.hasError()) {
+            showError(filterMoviesViewModel.getErrorMessage());
+            return;
+        }
+
+        List<Movie> filteredMovies = filterMoviesViewModel.getFilteredMovies();
+        if (filteredMovies != null && !filteredMovies.isEmpty()) {
+            // Display filtered movies
+            showResults(filteredMovies, 1, 1);
+            List<String> genreNames = filterMoviesViewModel.getSelectedGenreNames();
+            String genreText = String.join(", ", genreNames);
+            setStatus("Showing " + filteredMovies.size() + " movies filtered by: " + genreText);
+        } else {
+            // No movies found
+            resultsPanel.removeAll();
+            resultsPanel.revalidate();
+            resultsPanel.repaint();
+            setStatus("No movies found for selected genres.");
+        }
+    }
 
     private JPanel createMovieCard(Movie movie) {
         JPanel card = new JPanel(new BorderLayout(10, 0));
@@ -582,10 +744,10 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
                 if (currentState != null) {
                     String username = currentState.getUsername();
                     String movieId = movie.getMovieId();
-                    
+
                     // Record the movie to watch history
                     recordWatchHistoryController.recordMovie(username, movieId);
-                    
+
                     // Update button appearance
                     addToHistoryBtn.setText("Watched");
                     addToHistoryBtn.setBackground(new Color(22, 163, 74));

--- a/src/test/java/use_case/filter_movies/FilterMoviesInteractorTest.java
+++ b/src/test/java/use_case/filter_movies/FilterMoviesInteractorTest.java
@@ -162,22 +162,22 @@ class FilterMoviesInteractorTest {
     @Test
     void testGetGenreName() {
         // Test valid genre IDs
-        assertEquals("Action", FilterMoviesInteractor.getGenreName(28));
-        assertEquals("Comedy", FilterMoviesInteractor.getGenreName(35));
-        assertEquals("Horror", FilterMoviesInteractor.getGenreName(27));
-        assertEquals("Science Fiction", FilterMoviesInteractor.getGenreName(878));
-        assertEquals("Adventure", FilterMoviesInteractor.getGenreName(12));
-        assertEquals("Drama", FilterMoviesInteractor.getGenreName(18));
+        assertEquals("Action", common.GenreUtils.getGenreName(28));
+        assertEquals("Comedy", common.GenreUtils.getGenreName(35));
+        assertEquals("Horror", common.GenreUtils.getGenreName(27));
+        assertEquals("Science Fiction", common.GenreUtils.getGenreName(878));
+        assertEquals("Adventure", common.GenreUtils.getGenreName(12));
+        assertEquals("Drama", common.GenreUtils.getGenreName(18));
 
         // Test invalid genre ID
-        assertNull(FilterMoviesInteractor.getGenreName(999));
-        assertNull(FilterMoviesInteractor.getGenreName(-1));
+        assertNull(common.GenreUtils.getGenreName(999));
+        assertNull(common.GenreUtils.getGenreName(-1));
     }
 
     @Test
     void testGetAllGenres() {
         // Act
-        var allGenres = FilterMoviesInteractor.getAllGenres();
+        var allGenres = common.GenreUtils.getAllGenres();
 
         // Assert
         assertNotNull(allGenres);
@@ -192,8 +192,8 @@ class FilterMoviesInteractorTest {
     @Test
     void testGetAllGenresReturnsCopy() {
         // Act
-        var allGenres1 = FilterMoviesInteractor.getAllGenres();
-        var allGenres2 = FilterMoviesInteractor.getAllGenres();
+        var allGenres1 = common.GenreUtils.getAllGenres();
+        var allGenres2 = common.GenreUtils.getAllGenres();
 
         // Assert - should be different instances
         assertNotSame(allGenres1, allGenres2, "Should return a copy, not the same instance");
@@ -232,6 +232,12 @@ class FilterMoviesInteractorTest {
         public List<Movie> filterByGenres(List<Integer> genreIds) {
             this.lastGenreIdsCalled = genreIds != null ? new ArrayList<>(genreIds) : null;
             return new ArrayList<>(moviesToReturn);
+        }
+
+        @Override
+        public use_case.common.PagedMovieResult getPopularMovies(int page)
+                throws use_case.common.MovieDataAccessException {
+            return new use_case.common.PagedMovieResult(Collections.emptyList(), page, 1);
         }
     }
 

--- a/src/test/java/use_case/record_watchhistory/RecordWatchHistoryInteractorTest.java
+++ b/src/test/java/use_case/record_watchhistory/RecordWatchHistoryInteractorTest.java
@@ -76,13 +76,26 @@ class RecordWatchHistoryInteractorTest {
             }
 
             @Override
-            public use_case.common.PagedMovieResult searchByTitle(String query, int page) {
-                throw new UnsupportedOperationException("Not implemented in test");
+            public use_case.common.PagedMovieResult searchByTitle(String query, int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
 
             @Override
             public List<Movie> filterByGenres(List<Integer> genreIds) {
                 return List.of();
+            }
+
+            @Override
+            public use_case.common.PagedMovieResult getPopularMovies(int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
         };
 
@@ -176,13 +189,26 @@ class RecordWatchHistoryInteractorTest {
             }
 
             @Override
-            public use_case.common.PagedMovieResult searchByTitle(String query, int page) {
-                throw new UnsupportedOperationException("Not implemented in test");
+            public use_case.common.PagedMovieResult searchByTitle(String query, int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
 
             @Override
             public List<Movie> filterByGenres(List<Integer> genreIds) {
                 return List.of();
+            }
+
+            @Override
+            public use_case.common.PagedMovieResult getPopularMovies(int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
         };
 
@@ -278,13 +304,26 @@ class RecordWatchHistoryInteractorTest {
             }
 
             @Override
-            public use_case.common.PagedMovieResult searchByTitle(String query, int page) {
-                throw new UnsupportedOperationException("Not implemented in test");
+            public use_case.common.PagedMovieResult searchByTitle(String query, int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
 
             @Override
             public List<Movie> filterByGenres(List<Integer> genreIds) {
                 return List.of();
+            }
+
+            @Override
+            public use_case.common.PagedMovieResult getPopularMovies(int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
         };
 
@@ -510,13 +549,26 @@ class RecordWatchHistoryInteractorTest {
             }
 
             @Override
-            public use_case.common.PagedMovieResult searchByTitle(String query, int page) {
-                throw new UnsupportedOperationException("Not implemented in test");
+            public use_case.common.PagedMovieResult searchByTitle(String query, int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
 
             @Override
             public List<Movie> filterByGenres(List<Integer> genreIds) {
                 return List.of();
+            }
+
+            @Override
+            public use_case.common.PagedMovieResult getPopularMovies(int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
         };
 
@@ -596,13 +648,26 @@ class RecordWatchHistoryInteractorTest {
             }
 
             @Override
-            public use_case.common.PagedMovieResult searchByTitle(String query, int page) {
-                throw new UnsupportedOperationException("Not implemented in test");
+            public use_case.common.PagedMovieResult searchByTitle(String query, int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
 
             @Override
             public List<Movie> filterByGenres(List<Integer> genreIds) {
                 return List.of();
+            }
+
+            @Override
+            public use_case.common.PagedMovieResult getPopularMovies(int page)
+                    throws use_case.common.MovieDataAccessException {
+                throw new use_case.common.MovieDataAccessException(
+                        use_case.common.MovieDataAccessException.Type.UNKNOWN,
+                        "Not implemented in test"
+                );
             }
         };
 

--- a/src/test/java/use_case/review_movie/ReviewMovieInteractorTest.java
+++ b/src/test/java/use_case/review_movie/ReviewMovieInteractorTest.java
@@ -87,6 +87,11 @@ class ReviewMovieInteractorTest {
         public List<Movie> filterByGenres(List<Integer> genres) {
             return List.of();
         }
+
+        @Override
+        public PagedMovieResult getPopularMovies(int page) throws MovieDataAccessException {
+            return new PagedMovieResult(List.of(), page, 1);
+        }
     }
 
     @Test


### PR DESCRIPTION
This update fixes a Clean Architecture issue in the Filter Movies feature. Before, the filtering logic relied on UI state and handled genre formatting in the view layer, which mixed responsibilities and made the use case harder to test.


- The interactor doesn't depend on the UI.
- All movies to be filtered are now passed through the request model.

- GenreUtils now handles genre ID → name conversion.
- This keeps formatting logic out of the UI and places it in a shared domain-friendly location.

- The controller prepares all the data (movies + selected genres) before calling the interactor.
- This gives the proper flow: Controller → Interactor → Presenter → ViewModel → UI.

- Views does not reach into business logic.
- It simply forwards user actions and display the results.